### PR TITLE
Added simple pagination, added milliseconds to db

### DIFF
--- a/php/hireinsocial/db/migrations/2020/01/Version20200101144433.php
+++ b/php/hireinsocial/db/migrations/2020/01/Version20200101144433.php
@@ -19,7 +19,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20191228200120 extends AbstractMigration
+final class Version20200101144433 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
@@ -29,23 +29,23 @@ final class Version20191228200120 extends AbstractMigration
         $this->addSql('CREATE TABLE his_specialization (id UUID NOT NULL, slug VARCHAR(255) NOT NULL, facebook_channel_page_id VARCHAR(255) DEFAULT NULL, facebook_channel_page_access_token VARCHAR(255) DEFAULT NULL, facebook_channel_group_id VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12B989D9B62 ON his_specialization (slug)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12BA719CCF6 ON his_specialization (facebook_channel_group_id)');
-        $this->addSql('CREATE TABLE his_job_offer_pdf (id UUID NOT NULL, offer_id UUID NOT NULL, path VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_job_offer_pdf (id UUID NOT NULL, offer_id UUID NOT NULL, path VARCHAR(255) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_job_offer_pdf.created_at IS \'(DC2Type:datetime_immutable)\'');
-        $this->addSql('CREATE TABLE his_job_offer_application (id UUID NOT NULL, offer_id UUID NOT NULL, email_hash VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_job_offer_application (id UUID NOT NULL, offer_id UUID NOT NULL, email_hash VARCHAR(255) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_job_offer_application.created_at IS \'(DC2Type:datetime_immutable)\'');
-        $this->addSql('CREATE TABLE his_job_offer_slug (slug TEXT NOT NULL, offer_id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(slug))');
+        $this->addSql('CREATE TABLE his_job_offer_slug (slug TEXT NOT NULL, offer_id UUID NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(slug))');
         $this->addSql('COMMENT ON COLUMN his_job_offer_slug.created_at IS \'(DC2Type:datetime_immutable)\'');
-        $this->addSql('CREATE TABLE his_user (id UUID NOT NULL, email TEXT NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, blocked_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, fb_user_app_id VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_user (id UUID NOT NULL, email TEXT NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, blocked_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, fb_user_app_id VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX idx_unique_fb_user_app_id ON his_user (fb_user_app_id)');
         $this->addSql('CREATE UNIQUE INDEX idx_unique_email ON his_user (email)');
         $this->addSql('COMMENT ON COLUMN his_user.created_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('COMMENT ON COLUMN his_user.blocked_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('CREATE TABLE his_facebook_post (fb_id VARCHAR(255) NOT NULL, job_offer_id UUID NOT NULL, PRIMARY KEY(fb_id))');
-        $this->addSql('CREATE TABLE his_extra_offer (id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, expires_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, user_id UUID NOT NULL, used_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, offer_id UUID DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_extra_offer (id UUID NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, expires_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, user_id UUID NOT NULL, used_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, offer_id UUID DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_extra_offer.created_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('COMMENT ON COLUMN his_extra_offer.expires_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('COMMENT ON COLUMN his_extra_offer.used_at IS \'(DC2Type:datetime_immutable)\'');
-        $this->addSql('CREATE TABLE his_job_offer (id UUID NOT NULL, email_hash VARCHAR(255) NOT NULL, user_id UUID NOT NULL, specialization_id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, salary JSON DEFAULT NULL, removed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, company_name VARCHAR(255) NOT NULL, company_url VARCHAR(2083) NOT NULL, company_description VARCHAR(512) NOT NULL, position_name VARCHAR(255) NOT NULL, position_description VARCHAR(1024) NOT NULL, location_remote BOOLEAN NOT NULL, location_name VARCHAR(512) DEFAULT NULL, location_lat DOUBLE PRECISION DEFAULT NULL, location_lng DOUBLE PRECISION DEFAULT NULL, contract_type VARCHAR(255) NOT NULL, description_requirements VARCHAR(1024) NOT NULL, description_benefits VARCHAR(1024) NOT NULL, contact_email VARCHAR(255) NOT NULL, contact_name VARCHAR(255) NOT NULL, contact_phone VARCHAR(16) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_job_offer (id UUID NOT NULL, email_hash VARCHAR(255) NOT NULL, user_id UUID NOT NULL, specialization_id UUID NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, salary JSON DEFAULT NULL, removed_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, company_name VARCHAR(255) NOT NULL, company_url VARCHAR(2083) NOT NULL, company_description VARCHAR(512) NOT NULL, position_name VARCHAR(255) NOT NULL, position_description VARCHAR(1024) NOT NULL, location_remote BOOLEAN NOT NULL, location_name VARCHAR(512) DEFAULT NULL, location_lat DOUBLE PRECISION DEFAULT NULL, location_lng DOUBLE PRECISION DEFAULT NULL, contract_type VARCHAR(255) NOT NULL, description_requirements VARCHAR(1024) NOT NULL, description_benefits VARCHAR(1024) NOT NULL, contact_email VARCHAR(255) NOT NULL, contact_name VARCHAR(255) NOT NULL, contact_phone VARCHAR(16) DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_job_offer.created_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('COMMENT ON COLUMN his_job_offer.salary IS \'(DC2Type:his_offer_salary)\'');
         $this->addSql('COMMENT ON COLUMN his_job_offer.removed_at IS \'(DC2Type:datetime_immutable)\'');

--- a/php/hireinsocial/resources/templates/en-US/ui/offers/base.html.twig
+++ b/php/hireinsocial/resources/templates/en-US/ui/offers/base.html.twig
@@ -24,11 +24,11 @@
 </head>
 <body class="bg-light">
 
-{{ render(controller('App\\Offers\\Controller\\LayoutController::navbarAction')) }}
+{{ render_esi(controller('App\\Offers\\Controller\\LayoutController::navbarAction')) }}
 
 <div class="container">
     {% block header %}
-        {{ render(controller('App\\Offers\\Controller\\LayoutController::headerAction')) }}
+        {{ render_esi(controller('App\\Offers\\Controller\\LayoutController::headerAction')) }}
     {% endblock %}
 
     {% for label, messages in app.flashes(['warning', 'error', 'success']) %}

--- a/php/hireinsocial/resources/templates/en-US/ui/offers/home/index.html.twig
+++ b/php/hireinsocial/resources/templates/en-US/ui/offers/home/index.html.twig
@@ -22,4 +22,18 @@
     {% endfor %}
     </div>
 </div>
+{% if offersMore > offers|length %}
+    <p class="mt-2">
+        {% if showingOlder %}
+            <a class="btn btn-primary mr-2" href="{{ url('home') }}">Show latest</a>
+        {% endif %}
+        <a class="btn btn-secondary" href="{{ url('home', {specSlug: specialization.slug, after: offers.last.id.toString}) }}">Show more</a>
+    </p>
+{% else %}
+    {% if showingOlder %}
+        <p class="mt-2">
+            <a class="btn btn-primary" href="{{ url('home') }}">Show latest</a>
+        </p>
+    {% endif %}
+{% endif %}
 {% endblock %}

--- a/php/hireinsocial/resources/templates/en-US/ui/offers/specialization/offers.html.twig
+++ b/php/hireinsocial/resources/templates/en-US/ui/offers/specialization/offers.html.twig
@@ -45,6 +45,20 @@
                 {% endfor %}
                 </div>
             </div>
+            {% if offersMore > offers|length %}
+            <p class="mt-2">
+                {% if showingOlder %}
+                    <a class="btn btn-primary mr-2" href="{{ url('specialization_offers', {specSlug: specialization.slug}) }}">Show latest</a>
+                {% endif %}
+                <a class="btn btn-secondary" href="{{ url('specialization_offers', {specSlug: specialization.slug, after: offers.last.id.toString}) }}">Show more</a>
+            </p>
+            {% else %}
+                {% if showingOlder %}
+                    <p class="mt-2">
+                        <a class="btn btn-primary" href="{{ url('specialization_offers', {specSlug: specialization.slug}) }}">Show latest</a>
+                    </p>
+                {% endif %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/php/hireinsocial/resources/templates/en-US/ui/offers/user/profile.html.twig
+++ b/php/hireinsocial/resources/templates/en-US/ui/offers/user/profile.html.twig
@@ -19,7 +19,7 @@
                 </div>
             </div>
             <div class="col-md-9">
-                <h3>Last 20 Offers</h3>
+                <h3>Your Offers</h3>
                 <div class="card">
                     <div class="card-body">
                         {% for offer in offers %}
@@ -41,6 +41,20 @@
                         {% endfor %}
                     </div>
                 </div>
+                {% if offersMore > offers|length %}
+                    <p class="mt-2">
+                        {% if showingOlder %}
+                            <a class="btn btn-primary mr-2" href="{{ url('user_profile') }}">Show latest</a>
+                        {% endif %}
+                        <a class="btn btn-secondary" href="{{ url('user_profile', {after: offers.last.id.toString}) }}">Show older</a>
+                    </p>
+                {% else %}
+                    {% if showingOlder %}
+                        <p class="mt-2">
+                            <a class="btn btn-primary" href="{{ url('user_profile') }}">Show latest</a>
+                        </p>
+                    {% endif %}
+                {% endif %}
             </div>
         </div>
     </div>

--- a/php/hireinsocial/src/App/Offers/Command/Email/ScanMessages.php
+++ b/php/hireinsocial/src/App/Offers/Command/Email/ScanMessages.php
@@ -85,7 +85,7 @@ final class ScanMessages extends Command
     protected function initialize(InputInterface $input, OutputInterface $output) : void
     {
         $this->io = new SymfonyStyle($input, $output);
-        $this->tmpBasePath = sys_get_temp_dir() . '/' . uniqid('his_email_' . $input->getOption('mailbox') . '_');
+        $this->tmpBasePath = sys_get_temp_dir() . '/' . uniqid('his_email_' . $input->getOption('mailbox') . '_', true);
         $this->fs->mkdir($this->tmpBasePath);
 
         $this->io->title('Mailbox Scan');

--- a/php/hireinsocial/src/App/Offers/Command/Offer/Test/PostOffer.php
+++ b/php/hireinsocial/src/App/Offers/Command/Offer/Test/PostOffer.php
@@ -75,6 +75,7 @@ final class PostOffer extends Command
         $this
             ->setDescription('Test posting job offer with automatically generated fake data. This offer also generate fake user.')
             ->addArgument('specialization', InputArgument::REQUIRED, 'Specialization slug where for which test offer should be posted.')
+            ->addOption('title', null, InputOption::VALUE_OPTIONAL, 'Offer title', 'Software Developer')
             ->addOption('no-salary', null, InputOption::VALUE_OPTIONAL, 'Pass this option when you want to test offer without salary', false)
             ->addOption('post-facebook-group', null, InputOption::VALUE_OPTIONAL, 'Post offer to facebook group assigned to the specialization', false)
             ->addOption('offer-pdf', null, InputOption::VALUE_OPTIONAL, 'Path to offer PDF file.')
@@ -129,7 +130,7 @@ final class PostOffer extends Command
                         'Hire in Social is recruiting portal that connects recruiters with candidates'
                     ),
                     new Position(
-                        'Software Developer',
+                        $input->getOption('title'),
                         'Full stack Software developer position, you will work mostly on web applications with automated and scalable infrastructure.'
                     ),
                     new Location($faker->boolean, $faker->country, new LatLng($faker->latitude, $faker->longitude)),

--- a/php/hireinsocial/src/App/Offers/Controller/IndexController.php
+++ b/php/hireinsocial/src/App/Offers/Controller/IndexController.php
@@ -35,13 +35,21 @@ final class IndexController extends AbstractController
     {
         /** @var OfferFilter $offerFilter */
         $offerFilter = OfferFilter::all()
-            ->changeSize(50, 0);
+            ->max(20);
 
         $offers = $this->offers->offerQuery()->findAll($offerFilter);
+
+        if ($request->query->has('after')) {
+            $offerFilter->showAfter($request->query->get('after'));
+        }
+
+        $offerMore = $this->offers->offerQuery()->count($offerFilter);
 
         return $this->render('@offers/home/index.html.twig', [
             'specializations' => $this->offers->specializationQuery()->all(),
             'offers' => $offers,
+            'offersMore' => $offerMore,
+            'showingOlder' => $request->query->has('after'),
         ]);
     }
 

--- a/php/hireinsocial/src/App/Offers/Controller/Offer/OfferToForm.php
+++ b/php/hireinsocial/src/App/Offers/Controller/Offer/OfferToForm.php
@@ -77,7 +77,7 @@ class OfferToForm
                 'benefits' => $offer->description()->benefits(),
             ],
             'contact'=> [
-                'name' => $offer->contact()->phone(),
+                'name' => $offer->contact()->name(),
                 'email' => $offer->contact()->email(),
                 'phone' => $offer->contact()->phone(),
             ],

--- a/php/hireinsocial/src/App/Offers/Controller/SpecializationController.php
+++ b/php/hireinsocial/src/App/Offers/Controller/SpecializationController.php
@@ -42,7 +42,7 @@ final class SpecializationController extends AbstractController
 
         /** @var OfferFilter $offerFilter */
         $offerFilter = OfferFilter::allFor($specialization->slug())
-            ->changeSize(20, 0);
+            ->max(20);
 
         $form = $this->createForm(OfferFilterType::class)->handleRequest($request);
 
@@ -60,12 +60,21 @@ final class SpecializationController extends AbstractController
             }
         }
 
+        $total = $this->offers->offerQuery()->count($offerFilter);
+
+        if ($request->query->has('after')) {
+            $offerFilter->showAfter($request->query->get('after'));
+        }
+
         $offers = $this->offers->offerQuery()->findAll($offerFilter);
+        $offerMore = $this->offers->offerQuery()->count($offerFilter);
 
         return $this->render('@offers/specialization/offers.html.twig', [
-            'total' => $this->offers->offerQuery()->count($offerFilter),
-            'specialization' => $specialization,
+            'total' => $total,
             'offers' => $offers,
+            'offersMore' => $offerMore,
+            'showingOlder' => $request->query->has('after'),
+            'specialization' => $specialization,
             'form' => $form->createView(),
             'queryParameters' => $request->query->all(),
             'throttleLimit' => $this->offers->offerThrottleQuery()->limit(),

--- a/php/hireinsocial/src/App/Offers/Controller/UserController.php
+++ b/php/hireinsocial/src/App/Offers/Controller/UserController.php
@@ -55,16 +55,24 @@ final class UserController extends AbstractController
         /** @var OfferFilter $offerFilter */
         $offerFilter = OfferFilter::all()
             ->belongsTo($userId)
-            ->changeSize(20, 0);
+            ->max(5);
+
+        if ($request->query->has('after')) {
+            $offerFilter->showAfter($request->query->get('after'));
+        }
 
         $offers = $this->offers->offerQuery()->findAll($offerFilter);
+        $offerMore = $this->offers->offerQuery()->count($offerFilter);
 
         return $this->render('@offers/user/profile.html.twig', [
+            'showingOlder' => $request->query->has('after'),
             'user' => $this->offers->userQuery()->findById($userId),
+            'offersMore' => $offerMore,
             'offersLeft' => $this->offers->offerThrottleQuery()->offersLeft($userId),
             'extraOffersCount' => $this->offers->extraOffersQuery()->countNotExpired($userId),
             'extraOffer' => $this->offers->extraOffersQuery()->findClosesToExpire($userId),
             'offers' => $offers,
+            'totalOffers' => $this->offers->offerQuery()->count($offerFilter),
         ]);
     }
 }

--- a/php/hireinsocial/src/App/symfony.php
+++ b/php/hireinsocial/src/App/symfony.php
@@ -26,6 +26,9 @@ function symfony(Config $config, Offers $offers) : SymfonyKernel
         'framework' => [
             'secret' => $config->getString(Config::SYMFONY_SECRET),
             'csrf_protection' => null,
+            'esi' => [
+                'enabled' => true,
+            ],
             'validation' => [
                 'enabled' => true,
                 'enable_annotations' => false,

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Query/AbstractFilter.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Query/AbstractFilter.php
@@ -24,9 +24,9 @@ abstract class AbstractFilter
     protected $limit = 50;
 
     /**
-     * @var int
+     * @var int|null
      */
-    protected $offset = 0;
+    protected $offset;
 
     /**
      * @var mixed[]
@@ -37,9 +37,20 @@ abstract class AbstractFilter
     {
         Assertion::greaterOrEqualThan($offset, 0);
         Assertion::greaterThan($limit, 0);
+        Assertion::lessOrEqualThan($limit, 50);
 
         $this->limit = $limit;
         $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function max(int $limit) : self
+    {
+        Assertion::greaterThan($limit, 0);
+        Assertion::lessOrEqualThan($limit, 50);
+
+        $this->limit = $limit;
 
         return $this;
     }
@@ -49,7 +60,7 @@ abstract class AbstractFilter
         return $this->limit;
     }
 
-    public function offset() : int
+    public function offset() : ?int
     {
         return $this->offset;
     }

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Offer/Model/Offers.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Offer/Model/Offers.php
@@ -24,4 +24,13 @@ final class Offers extends \ArrayObject
     {
         return \current((array) $this);
     }
+
+    public function last() : Offer
+    {
+        $offers = (array) $this;
+        /** @var Offer $offer */
+        $offer = \end($offers);
+
+        return $offer;
+    }
 }

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Offer/OfferFilter.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Offer/OfferFilter.php
@@ -42,7 +42,7 @@ final class OfferFilter extends AbstractFilter
     private $sinceDate;
 
     /**
-     * @var \DateTimeImmutable
+     * @var \DateTimeImmutable|null
      */
     private $tillDate;
 
@@ -61,10 +61,14 @@ final class OfferFilter extends AbstractFilter
      */
     private $userId;
 
+    /**
+     * @var string|null
+     */
+    private $afterOffer;
+
     private function __construct()
     {
         $this->newerThan(new \DateTimeImmutable('-2 weeks', new \DateTimeZone('UTC')));
-        $this->olderThan(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
     }
 
     public static function allFor(string $specialization) : self
@@ -98,12 +102,19 @@ final class OfferFilter extends AbstractFilter
         return $this;
     }
 
+    public function showAfter(string $offerId) : self
+    {
+        $this->afterOffer = $offerId;
+
+        return $this;
+    }
+
     public function sinceDate() : \DateTimeImmutable
     {
         return $this->sinceDate;
     }
 
-    public function tillDate() : \DateTimeImmutable
+    public function tillDate() : ?\DateTimeImmutable
     {
         return $this->tillDate;
     }
@@ -147,6 +158,11 @@ final class OfferFilter extends AbstractFilter
     public function userId() : ?string
     {
         return $this->userId;
+    }
+
+    public function afterOfferId() : ?string
+    {
+        return $this->afterOffer;
     }
 
     public function sortBy(string $columnType) : self

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Application/Offer/DbalOfferThrottleQuery.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Application/Offer/DbalOfferThrottleQuery.php
@@ -15,7 +15,6 @@ namespace HireInSocial\Offers\Infrastructure\Doctrine\DBAL\Application\Offer;
 
 use function array_key_exists;
 use DateInterval;
-use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use HireInSocial\Offers\Application\Query\Offer\OfferThrottleQuery;
 use HireInSocial\Offers\Application\System\Calendar;
@@ -105,7 +104,7 @@ final class DbalOfferThrottleQuery implements OfferThrottleQuery
             ->andWhere('o.created_at >= :since')
             ->setParameters([
                 'userId' => $userId,
-                'since' => $this->calendar->currentTime()->sub($this->since)->format(DateTimeInterface::ISO8601),
+                'since' => $this->calendar->currentTime()->sub($this->since)->format($this->connection->getDatabasePlatform()->getDateTimeFormatString()),
             ])
             ->execute()
             ->fetchColumn();

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Platform/PostgreSQL11Keywords.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Platform/PostgreSQL11Keywords.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Infrastructure\Doctrine\DBAL\Platform;
+
+use Doctrine\DBAL\Platforms\Keywords\PostgreSQL94Keywords;
+
+class PostgreSQL11Keywords extends PostgreSQL94Keywords
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName() : string
+    {
+        return 'PostgreSQL11';
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Platform/PostgreSQL11Platform.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Platform/PostgreSQL11Platform.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Infrastructure\Doctrine\DBAL\Platform;
+
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+
+class PostgreSQL11Platform extends PostgreSQL100Platform
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function getReservedKeywordsClass() : string
+    {
+        return PostgreSQL11Keywords::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
+    {
+        return 'TIMESTAMP(6) WITHOUT TIME ZONE';
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
+    {
+        return 'TIMESTAMP(6) WITH TIME ZONE';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNowExpression() : string
+    {
+        return 'LOCALTIMESTAMP(6)';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
+    {
+        return 'TIME(6) WITHOUT TIME ZONE';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormatString() : string
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeTzFormatString() : string
+    {
+        return 'Y-m-d H:i:s.uO';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTimeFormatString() : string
+    {
+        return 'H:i:s.u';
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/dbal.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/dbal.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 use HireInSocial\Offers\Application\Config;
+use HireInSocial\Offers\Infrastructure\Doctrine\DBAL\Platform\PostgreSQL11Platform;
 use HireInSocial\Offers\Infrastructure\Doctrine\DBAL\Types\Offer\SalaryType;
 
 function dbal(Config $config) : Connection
@@ -34,6 +35,7 @@ function dbal(Config $config) : Connection
             'host' => $config->getString(Config::DB_HOST),
             'port' => $config->getInt(Config::DB_PORT),
             'driver' => 'pdo_pgsql',
+            'platform' => new PostgreSQL11Platform(),
         ],
         new Configuration()
     );


### PR DESCRIPTION
Added simple offers pagination to homepage, specialization pager and user profile page, with "show older"/"show latest" offers.

![image](https://user-images.githubusercontent.com/1921950/71642770-f4bb4000-2cb0-11ea-9e97-4a4bb6b48d2d.png)

In order to increase precision I also changed Doctrine PostgreSQL100Platform to PostgreSQL11Platform that changes `TIMESTAMP(0)` and `TIME(0)` into `TIMESTAMP(6)` and `TIME(6)` (saving also milliseconds with precision equal to 6) 