### PR TITLE
Added specialization twitter social channel

### DIFF
--- a/php/hireinsocial/bin/offers
+++ b/php/hireinsocial/bin/offers
@@ -2,6 +2,7 @@
 <?php
 
 use App\Offers\Command\Offer\RemoveOffer;
+use App\Offers\Command\Specialization\SetTwitterChannel;
 use App\Offers\Command\User\AddExtraOffers;
 use App\Offers\Command\User\BlockUser;
 use HireInSocial\Offers\Application\Config;
@@ -27,6 +28,7 @@ $application = new Application('Hire in Social - Offers');
 $application->add(new Test\PostOffer($offers, $config->getString(Config::LOCALE)));
 $application->add(new CreateSpecialization($offers));
 $application->add(new SetFacebookChannel($offers));
+$application->add(new SetTwitterChannel($offers));
 $application->add(new RemoveFacebookChannel($offers));
 $application->add(new PerformanceCheckCommand($offers, $config));
 $application->add(new RemoveOffer($offers));

--- a/php/hireinsocial/bin/offers
+++ b/php/hireinsocial/bin/offers
@@ -2,6 +2,7 @@
 <?php
 
 use App\Offers\Command\Offer\RemoveOffer;
+use App\Offers\Command\Specialization\RemoveTwitterChannel;
 use App\Offers\Command\Specialization\SetTwitterChannel;
 use App\Offers\Command\User\AddExtraOffers;
 use App\Offers\Command\User\BlockUser;
@@ -30,6 +31,7 @@ $application->add(new CreateSpecialization($offers));
 $application->add(new SetFacebookChannel($offers));
 $application->add(new SetTwitterChannel($offers));
 $application->add(new RemoveFacebookChannel($offers));
+$application->add(new RemoveTwitterChannel($offers));
 $application->add(new PerformanceCheckCommand($offers, $config));
 $application->add(new RemoveOffer($offers));
 $application->add(new BlockUser($offers));

--- a/php/hireinsocial/db/migrations/2020/01/Version20200117222717.php
+++ b/php/hireinsocial/db/migrations/2020/01/Version20200117222717.php
@@ -19,16 +19,17 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20200106111521 extends AbstractMigration
+final class Version20200117222717 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE TABLE his_specialization (id UUID NOT NULL, slug VARCHAR(255) NOT NULL, facebook_channel_page_id VARCHAR(255) DEFAULT NULL, facebook_channel_page_access_token VARCHAR(255) DEFAULT NULL, facebook_channel_group_id VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE his_specialization (id UUID NOT NULL, slug VARCHAR(255) NOT NULL, facebook_channel_page_id VARCHAR(255) DEFAULT NULL, facebook_channel_page_access_token VARCHAR(255) DEFAULT NULL, facebook_channel_group_id VARCHAR(255) DEFAULT NULL, twitter_account_id VARCHAR(255) DEFAULT NULL, twitter_screen_name VARCHAR(255) DEFAULT NULL, twittero_auth_token VARCHAR(255) DEFAULT NULL, twittero_auth_token_secret VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12B989D9B62 ON his_specialization (slug)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12BA719CCF6 ON his_specialization (facebook_channel_group_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12B322E56FB ON his_specialization (twitter_account_id)');
         $this->addSql('CREATE TABLE his_job_offer_pdf (id UUID NOT NULL, offer_id UUID NOT NULL, path VARCHAR(255) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_job_offer_pdf.created_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('CREATE TABLE his_job_offer_application (id UUID NOT NULL, offer_id UUID NOT NULL, email_hash VARCHAR(255) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');

--- a/php/hireinsocial/db/orm/mapping/xml/Specialization.Specialization.orm.xml
+++ b/php/hireinsocial/db/orm/mapping/xml/Specialization.Specialization.orm.xml
@@ -11,10 +11,15 @@
         <field name="facebookChannelPageId" nullable="true" />
         <field name="facebookChannelPageAccessToken" nullable="true" />
         <field name="facebookChannelGroupId" nullable="true" />
+        <field name="twitterAccountId" nullable="true" />
+        <field name="twitterScreenName" nullable="true" />
+        <field name="twitteroAuthToken" nullable="true" />
+        <field name="twitteroAuthTokenSecret" nullable="true" />
 
         <unique-constraints>
             <unique-constraint columns="slug" />
             <unique-constraint columns="facebook_channel_group_id" />
+            <unique-constraint columns="twitter_account_id" />
         </unique-constraints>
     </entity>
 </doctrine-mapping>

--- a/php/hireinsocial/src/App/Offers/Command/Specialization/RemoveTwitterChannel.php
+++ b/php/hireinsocial/src/App/Offers/Command/Specialization/RemoveTwitterChannel.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Offers\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\Specialization\RemoveTwitterChannel as SystemRemoveTwitterChannel;
+use HireInSocial\Offers\Offers;
+use function mb_strtolower;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+final class RemoveTwitterChannel extends Command
+{
+    public const NAME = 'specialization:channel:twitter:remove';
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = self::NAME;
+
+    /**
+     * @var Offers
+     */
+    private $offers;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(Offers $offers)
+    {
+        parent::__construct();
+
+        $this->offers = $offers;
+    }
+
+    protected function configure() : void
+    {
+        $this
+            ->setDescription('Remove Twitter channel from specialization.')
+            ->addArgument('slug', InputArgument::REQUIRED, 'Specialization slug')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output) : void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $this->io->note('Remove specialization Twitter channel');
+
+        if ($input->isInteractive()) {
+            $answer = $this->io->ask('Are you sure you want remove twitter channel from the specialization?', 'yes');
+
+            if (mb_strtolower($answer) !== 'yes') {
+                $this->io->note('Ok, action cancelled.');
+
+                return 1;
+            }
+        }
+
+        if (!$this->offers->specializationQuery()->findBySlug($input->getArgument('slug'))) {
+            $this->io->error(sprintf('Specialization slug "%s" does not exists.', $input->getArgument('slug')));
+
+            return 1;
+        }
+
+        try {
+            $this->offers->handle(new SystemRemoveTwitterChannel(
+                $input->getArgument('slug')
+            ));
+        } catch (Throwable $e) {
+            $this->io->error('Can\'t remove specialization twitter channel, check logs for more details.');
+
+            return 1;
+        }
+
+        $this->io->success('Specialization twitter channel removed');
+
+        return 0;
+    }
+}

--- a/php/hireinsocial/src/App/Offers/Command/Specialization/SetTwitterChannel.php
+++ b/php/hireinsocial/src/App/Offers/Command/Specialization/SetTwitterChannel.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Offers\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\Specialization\SetTwitterChannel as SystemSetTwitterChannel;
+use HireInSocial\Offers\Offers;
+use function mb_strtolower;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+final class SetTwitterChannel extends Command
+{
+    public const NAME = 'specialization:channel:twitter:set';
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = self::NAME;
+
+    /**
+     * @var Offers
+     */
+    private $offers;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(Offers $offers)
+    {
+        parent::__construct();
+
+        $this->offers = $offers;
+    }
+
+    protected function configure() : void
+    {
+        $this
+            ->setDescription('Set twitter channel for specialization.')
+            ->addArgument('slug', InputArgument::REQUIRED, 'Specialization slug')
+            ->addArgument('twitter_account_id', InputArgument::REQUIRED, 'Twitter account id')
+            ->addArgument('twitter_screen_name', InputArgument::REQUIRED, 'Twitter screen name (used to generate url to profile)')
+            ->addArgument('twitter_oauth_token', InputArgument::REQUIRED, 'Twitter account oAuth Token')
+            ->addArgument('twitter_oauth_secret', InputArgument::REQUIRED, 'Twitter account oAuth Secret')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output) : void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $this->io->note('Set specialization twitter channel');
+
+        if ($input->isInteractive()) {
+            $answer = $this->io->ask('Are you sure you want set twitter channel to the specialization?', 'yes');
+
+            if (mb_strtolower($answer) !== 'yes') {
+                $this->io->note('Ok, action cancelled.');
+
+                return 1;
+            }
+        }
+
+        if (!$this->offers->specializationQuery()->findBySlug($input->getArgument('slug'))) {
+            $this->io->error(sprintf('twitter slug "%s" does not exists.', $input->getArgument('slug')));
+
+            return 1;
+        }
+
+        try {
+            $this->offers->handle(new SystemSetTwitterChannel(
+                $input->getArgument('slug'),
+                $input->getArgument('twitter_account_id'),
+                $input->getArgument('twitter_screen_name'),
+                $input->getArgument('twitter_oauth_token'),
+                $input->getArgument('twitter_oauth_secret')
+            ));
+        } catch (Throwable $e) {
+            $this->io->error('Can\'t set specialization twitter channel, check logs for more details.');
+
+            return 1;
+        }
+
+        $this->io->success('Twitter channel added to the specialization');
+
+        return 0;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/RemoveTwitterChannel.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/RemoveTwitterChannel.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\ClassCommand;
+use HireInSocial\Offers\Application\System\Command;
+
+final class RemoveTwitterChannel implements Command
+{
+    use ClassCommand;
+
+    /**
+     * @var string
+     */
+    private $specSlug;
+
+    public function __construct(string $specSlug)
+    {
+        $this->specSlug = $specSlug;
+    }
+
+    public function specSlug() : string
+    {
+        return $this->specSlug;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/RemoveTwitterChannelHandler.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/RemoveTwitterChannelHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Command\Specialization;
+
+use HireInSocial\Offers\Application\Specialization\Specializations;
+use HireInSocial\Offers\Application\System\Handler;
+
+final class RemoveTwitterChannelHandler implements Handler
+{
+    /**
+     * @var Specializations
+     */
+    private $specializations;
+
+    public function __construct(Specializations $specializations)
+    {
+        $this->specializations = $specializations;
+    }
+
+    public function handles() : string
+    {
+        return RemoveTwitterChannel::class;
+    }
+
+    public function __invoke(RemoveTwitterChannel $command) : void
+    {
+        $specialization = $this->specializations->get($command->specSlug());
+
+        $specialization->removeTwitter();
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/SetTwitterChannel.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/SetTwitterChannel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\ClassCommand;
+use HireInSocial\Offers\Application\System\Command;
+
+final class SetTwitterChannel implements Command
+{
+    use ClassCommand;
+
+    /**
+     * @var string
+     */
+    private $specSlug;
+
+    /**
+     * @var string
+     */
+    private $accountId;
+
+    /**
+     * @var string
+     */
+    private $screenName;
+
+    /**
+     * @var string
+     */
+    private $oauthToken;
+
+    /**
+     * @var string
+     */
+    private $oauthSecret;
+
+    public function __construct(
+        string $specSlug,
+        string $accountId,
+        string $screenName,
+        string $oauthToken,
+        string $oauthSecret
+    ) {
+        $this->specSlug = $specSlug;
+        $this->accountId = $accountId;
+        $this->screenName = $screenName;
+        $this->oauthToken = $oauthToken;
+        $this->oauthSecret = $oauthSecret;
+    }
+
+    public function specSlug() : string
+    {
+        return $this->specSlug;
+    }
+
+    /**
+     * @return string
+     */
+    public function accountId() : string
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * @return string
+     */
+    public function screenName() : string
+    {
+        return $this->screenName;
+    }
+
+    /**
+     * @return string
+     */
+    public function oauthToken() : string
+    {
+        return $this->oauthToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function oauthSecret() : string
+    {
+        return $this->oauthSecret;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/SetTwitterChannelHandler.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Command/Specialization/SetTwitterChannelHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Command\Specialization;
+
+use HireInSocial\Offers\Application\Specialization\Specializations;
+use HireInSocial\Offers\Application\Specialization\TwitterChannel;
+use HireInSocial\Offers\Application\System\Handler;
+
+final class SetTwitterChannelHandler implements Handler
+{
+    /**
+     * @var Specializations
+     */
+    private $specializations;
+
+    public function __construct(Specializations $specializations)
+    {
+        $this->specializations = $specializations;
+    }
+
+    public function handles() : string
+    {
+        return SetTwitterChannel::class;
+    }
+
+    public function __invoke(SetTwitterChannel $command) : void
+    {
+        $specialization = $this->specializations->get($command->specSlug());
+
+        $specialization->setTwitter(new TwitterChannel(
+            $command->accountId(),
+            $command->screenName(),
+            $command->oauthToken(),
+            $command->oauthSecret()
+        ));
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Specialization/Model/Specialization.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Specialization/Model/Specialization.php
@@ -15,6 +15,7 @@ namespace HireInSocial\Offers\Application\Query\Specialization\Model;
 
 use HireInSocial\Offers\Application\Query\Specialization\Model\Specialization\FacebookChannel;
 use HireInSocial\Offers\Application\Query\Specialization\Model\Specialization\Offers;
+use HireInSocial\Offers\Application\Query\Specialization\Model\Specialization\TwitterChannel;
 use function mb_strtolower;
 
 final class Specialization
@@ -34,11 +35,17 @@ final class Specialization
      */
     private $facebookChannel;
 
-    public function __construct(string $slug, Offers $offers, ?FacebookChannel $facebookChannel)
+    /**
+     * @var TwitterChannel|null
+     */
+    private $twitterChannel;
+
+    public function __construct(string $slug, Offers $offers, ?FacebookChannel $facebookChannel = null, ?TwitterChannel $twitterChannel = null)
     {
         $this->slug = $slug;
         $this->offers = $offers;
         $this->facebookChannel = $facebookChannel;
+        $this->twitterChannel = $twitterChannel;
     }
 
     public function slug() : string
@@ -54,6 +61,11 @@ final class Specialization
     public function facebookChannel() : ?FacebookChannel
     {
         return $this->facebookChannel;
+    }
+
+    public function twitterChannel() : ?TwitterChannel
+    {
+        return $this->twitterChannel;
     }
 
     public function is(string $slug) : bool

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Specialization/Model/Specialization/TwitterChannel.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Query/Specialization/Model/Specialization/TwitterChannel.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Query\Specialization\Model\Specialization;
+
+final class TwitterChannel
+{
+    /**
+     * @var string
+     */
+    private $accountId;
+
+    /**
+     * @var string
+     */
+    private $screenName;
+
+    public function __construct(string $accountId, string $screenName)
+    {
+        $this->accountId = $accountId;
+        $this->screenName = \mb_strtolower($screenName);
+    }
+
+    /**
+     * @return string
+     */
+    public function accountId() : string
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * @return string
+     */
+    public function screenName() : string
+    {
+        return $this->screenName;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/FacebookChannel.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/FacebookChannel.php
@@ -19,12 +19,12 @@ use HireInSocial\Offers\Application\Facebook\Page;
 final class FacebookChannel
 {
     /**
-     * @var \HireInSocial\Offers\Application\Facebook\Page
+     * @var Page
      */
     private $page;
 
     /**
-     * @var \HireInSocial\Offers\Application\Facebook\Group
+     * @var Group
      */
     private $group;
 

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/Specialization.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/Specialization.php
@@ -46,6 +46,26 @@ class Specialization
      */
     private $facebookChannelGroupId;
 
+    /**
+     * @var string|null
+     */
+    private $twitterAccountId;
+
+    /**
+     * @var string|null
+     */
+    private $twitterScreenName;
+
+    /**
+     * @var string|null
+     */
+    private $twitteroAuthToken;
+
+    /**
+     * @var string|null
+     */
+    private $twitteroAuthTokenSecret;
+
     public function __construct(string $slug)
     {
         Assertion::regex(\mb_strtolower($slug), '/^[a-z\-\_]+$/');
@@ -77,11 +97,44 @@ class Specialization
         $this->facebookChannelGroupId = $facebookChannel->group()->fbId();
     }
 
+    public function setTwitter(TwitterChannel $twitterChannel) : void
+    {
+        $this->twitterAccountId = $twitterChannel->accountId();
+        $this->twitterScreenName = $twitterChannel->screenName();
+        $this->twitteroAuthToken = $twitterChannel->oauthToken();
+        $this->twitteroAuthTokenSecret = $twitterChannel->oauthTokenSecret();
+    }
+
     public function removeFacebook() : void
     {
         $this->facebookChannelPageId = null;
         $this->facebookChannelPageAccessToken = null;
         $this->facebookChannelGroupId = null;
+    }
+
+    public function removeTwitter() : void
+    {
+        $this->twitterAccountId = null;
+        $this->twitterScreenName = null;
+        $this->twitteroAuthToken = null;
+        $this->twitteroAuthTokenSecret = null;
+    }
+
+    public function twitterChannel() : ?TwitterChannel
+    {
+        if (!\is_null($this->twitterAccountId) &&
+            !\is_null($this->twitterScreenName) &&
+            !\is_null($this->twitteroAuthToken) &&
+            !\is_null($this->twitteroAuthTokenSecret)) {
+            return new TwitterChannel(
+                $this->twitterAccountId,
+                $this->twitterScreenName,
+                $this->twitteroAuthToken,
+                $this->twitteroAuthTokenSecret
+            );
+        }
+
+        return null;
     }
 
     public function facebookChannel() : ?FacebookChannel

--- a/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/TwitterChannel.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Application/Specialization/TwitterChannel.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Offers\Application\Specialization;
+
+use HireInSocial\Offers\Application\Assertion;
+
+final class TwitterChannel
+{
+    /**
+     * @var string
+     */
+    private $accountId;
+
+    /**
+     * @var string
+     */
+    private $screenName;
+
+    /**
+     * @var string
+     */
+    private $oauthToken;
+
+    /**
+     * @var string
+     */
+    private $oauthSecret;
+
+    public function __construct(string $accountId, string $screenName, string $oauthToken, string $oauthSecret)
+    {
+        Assertion::betweenLength($accountId, 3, 255);
+        Assertion::betweenLength($screenName, 3, 255);
+        Assertion::betweenLength($oauthToken, 3, 255);
+        Assertion::betweenLength($oauthSecret, 3, 255);
+
+        $this->accountId = $accountId;
+        $this->screenName = \mb_strtolower($screenName);
+        $this->oauthToken = $oauthToken;
+        $this->oauthSecret = $oauthSecret;
+    }
+
+    /**
+     * @return string
+     */
+    public function accountId() : string
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * @return string
+     */
+    public function screenName() : string
+    {
+        return $this->screenName;
+    }
+
+    /**
+     * @return string
+     */
+    public function oauthToken() : string
+    {
+        return $this->oauthToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function oauthTokenSecret() : string
+    {
+        return $this->oauthSecret;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Application/Specialization/DbalSpecializationQuery.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/Doctrine/DBAL/Application/Specialization/DbalSpecializationQuery.php
@@ -44,6 +44,8 @@ final class DbalSpecializationQuery implements SpecializationQuery
                      s.slug, 
                      s.facebook_channel_page_id as fb_page_id, 
                      s.facebook_channel_group_id as fb_group_id,
+                     s.twitter_account_id,
+                     s.twitter_screen_name,
                      (SELECT COUNT(*) FROM his_job_offer WHERE specialization_id = s.id) as offers_count
                   FROM his_specialization s 
                   ORDER BY offers_count desc
@@ -61,7 +63,9 @@ SQL
                s.id,
                s.slug, 
                s.facebook_channel_page_id as fb_page_id, 
-               s.facebook_channel_group_id as fb_group_id
+               s.facebook_channel_group_id as fb_group_id,
+               s.twitter_account_id,
+               s.twitter_screen_name
             FROM his_specialization s
             WHERE s.slug = :slug
 SQL
@@ -106,6 +110,12 @@ SQL
                 ? new FacebookChannel(
                     $data['fb_page_id'],
                     $data['fb_group_id']
+                )
+                : null,
+            ($data['twitter_account_id'])
+                ? new Specialization\TwitterChannel(
+                    $data['twitter_account_id'],
+                    $data['twitter_screen_name']
                 )
                 : null
         );

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/facade.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/facade.php
@@ -19,6 +19,7 @@ use HireInSocial\Offers\Application\Command\Offer\PostOfferHandler;
 use HireInSocial\Offers\Application\Command\Offer\RemoveOfferHandler;
 use HireInSocial\Offers\Application\Command\Specialization\CreateSpecializationHandler;
 use HireInSocial\Offers\Application\Command\Specialization\RemoveFacebookChannelHandler;
+use HireInSocial\Offers\Application\Command\Specialization\RemoveTwitterChannelHandler;
 use HireInSocial\Offers\Application\Command\Specialization\SetFacebookChannelHandler;
 use HireInSocial\Offers\Application\Command\Specialization\SetTwitterChannelHandler;
 use HireInSocial\Offers\Application\Command\User\AddExtraOffersHandler;
@@ -164,6 +165,9 @@ function offersFacade(Config $config) : Offers
                     $specializations
                 ),
                 new RemoveFacebookChannelHandler(
+                    $specializations
+                ),
+                new RemoveTwitterChannelHandler(
                     $specializations
                 ),
                 new PostOfferHandler(

--- a/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/facade.php
+++ b/php/hireinsocial/src/HireInSocial/Offers/Infrastructure/facade.php
@@ -20,6 +20,7 @@ use HireInSocial\Offers\Application\Command\Offer\RemoveOfferHandler;
 use HireInSocial\Offers\Application\Command\Specialization\CreateSpecializationHandler;
 use HireInSocial\Offers\Application\Command\Specialization\RemoveFacebookChannelHandler;
 use HireInSocial\Offers\Application\Command\Specialization\SetFacebookChannelHandler;
+use HireInSocial\Offers\Application\Command\Specialization\SetTwitterChannelHandler;
 use HireInSocial\Offers\Application\Command\User\AddExtraOffersHandler;
 use HireInSocial\Offers\Application\Command\User\BlockUserHandler;
 use HireInSocial\Offers\Application\Command\User\FacebookConnectHandler;
@@ -157,6 +158,9 @@ function offersFacade(Config $config) : Offers
                     $specializations
                 ),
                 new SetFacebookChannelHandler(
+                    $specializations
+                ),
+                new SetTwitterChannelHandler(
                     $specializations
                 ),
                 new RemoveFacebookChannelHandler(

--- a/php/hireinsocial/tests/HireInSocial/Tests/Offers/Application/Integration/Command/Specialization/RemoveTwitterChannelTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Offers/Application/Integration/Command/Specialization/RemoveTwitterChannelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Tests\Offers\Application\Integration\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\Specialization\CreateSpecialization;
+use HireInSocial\Offers\Application\Command\Specialization\RemoveTwitterChannel;
+use HireInSocial\Offers\Application\Command\Specialization\SetTwitterChannel;
+use HireInSocial\Tests\Offers\Application\Integration\HireInSocialTestCase;
+
+final class RemoveTwitterChannelTest extends HireInSocialTestCase
+{
+    public function test_remove_facebook_channel() : void
+    {
+        $slug = 'php';
+
+        $this->systemContext->offersFacade()->handle(new CreateSpecialization($slug));
+        $this->systemContext->offersFacade()->handle(new SetTwitterChannel($slug, 'twitter_id', 'screen_name', 'token', 'secret'));
+        $this->systemContext->offersFacade()->handle(new RemoveTwitterChannel($slug));
+
+        $this->assertNull(
+            $this->systemContext->offersFacade()->specializationQuery()->findBySlug($slug)->twitterChannel()
+        );
+    }
+}

--- a/php/hireinsocial/tests/HireInSocial/Tests/Offers/Application/Integration/Command/Specialization/SetTwitterChannelTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Offers/Application/Integration/Command/Specialization/SetTwitterChannelTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Hire in Social project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HireInSocial\Tests\Offers\Application\Integration\Command\Specialization;
+
+use HireInSocial\Offers\Application\Command\Specialization\CreateSpecialization;
+use HireInSocial\Offers\Application\Command\Specialization\SetTwitterChannel;
+use HireInSocial\Offers\Application\Query\Specialization\Model\Specialization\TwitterChannel;
+use HireInSocial\Tests\Offers\Application\Integration\HireInSocialTestCase;
+
+final class SetTwitterChannelTest extends HireInSocialTestCase
+{
+    public function test_set_specialization_twitter_channel() : void
+    {
+        $slug = 'php';
+
+        $this->systemContext->offersFacade()->handle(new CreateSpecialization($slug));
+        $this->systemContext->offersFacade()->handle(new SetTwitterChannel($slug, 'twitter_id', 'screen_name', 'token', 'secret'));
+
+        $this->assertEquals(
+            new TwitterChannel(
+                'twitter_id',
+                'screen_name'
+            ),
+            $this->systemContext->offersFacade()->specializationQuery()->findBySlug($slug)->twitterChannel()
+        );
+    }
+}


### PR DESCRIPTION
Like Facebook, specializations can now get also twitter social channel. It's the last step before allowing recruiter to choose if they want their offer to be also tweeted from specialization dedicated account. 